### PR TITLE
Feature: Use set if an array should contain only unique items

### DIFF
--- a/petstore.yaml
+++ b/petstore.yaml
@@ -710,6 +710,7 @@ components:
             wrapped: true
           items:
             type: string
+          uniqueItems: true
         tags:
           type: array
           xml:

--- a/src/main/java/com/nexenio/CppModernJson/CppModernJsonCodegen.java
+++ b/src/main/java/com/nexenio/CppModernJson/CppModernJsonCodegen.java
@@ -88,7 +88,10 @@ public class CppModernJsonCodegen extends AbstractCppCodegen implements CodegenC
     typeMapping.put("URI", "std::string");
     typeMapping.put("UUID", "std::string");
 
+    // std::vector might be overwritten to std::set if `uniqueItems` is set to true
     typeMapping.put("array", "std::vector");
+    // there actually isn't a type called "set", but we need to have a mapping to set in typeMapping to not make it a custom type
+    typeMapping.put("set", "std::set");
     typeMapping.put("binary", "std::string");
     typeMapping.put("map", "std::map");
     typeMapping.put("string", "std::string");
@@ -105,6 +108,7 @@ public class CppModernJsonCodegen extends AbstractCppCodegen implements CodegenC
     super.importMapping = new HashMap<String, String>();
     importMapping.put("std::vector", "#include <vector>");
     importMapping.put("std::map", "#include <map>");
+    importMapping.put("std::set", "#include <set>");
     importMapping.put("std::string", "#include <string>");
     importMapping.put("std::shared_ptr", "#include <memory>");
 
@@ -195,6 +199,11 @@ public class CppModernJsonCodegen extends AbstractCppCodegen implements CodegenC
 
       if (languageSpecificPrimitives.contains(type)) {
         return toModelName(type);
+      }
+
+      // if an array has "uniqueItems" set to true, we want to use std::set instead of std::vector
+      if((p instanceof ArraySchema) && p.getUniqueItems() != null && p.getUniqueItems() == true) {
+        type = "std::set";
       }
     } else {
       type = openAPIType;

--- a/src/main/resources/cpp-modern-json/source.mustache
+++ b/src/main/resources/cpp-modern-json/source.mustache
@@ -7,6 +7,8 @@
 {{! ---------------------------------------------------------------------- }}
 {{#models}}{{#model}}#include "{{classname}}.h"
 
+#include <tuple>
+
 #include "serialization.h"
 #include "utility.h"
 

--- a/src/main/resources/cpp-modern-json/struct-header.mustache
+++ b/src/main/resources/cpp-modern-json/struct-header.mustache
@@ -79,7 +79,7 @@ inline std::string to_string({{classname}}::{{enumName}} value) {
 {{/hasEnums}}
 
 // operator< is needed for std::set support
-friend operator<(const {{classname}}& l, const {{classname}}& r) {
+friend bool operator<(const {{classname}}& l, const {{classname}}& r) {
    return std::tie({{#vars}}l.{{baseName}}{{^-last}},{{/-last}}{{/vars}}) < std::tie({{#vars}}r.{{baseName}}{{^-last}},{{/-last}}{{/vars}});
 }
 

--- a/src/main/resources/cpp-modern-json/struct-header.mustache
+++ b/src/main/resources/cpp-modern-json/struct-header.mustache
@@ -1,4 +1,5 @@
 #include <nlohmann/json.hpp>
+#include <tuple>
 
 {{#hasOptional}}#include <optional>
 {{/hasOptional}}
@@ -76,6 +77,11 @@ inline std::string to_string({{classname}}::{{enumName}} value) {
 {{/isEnum}}
 {{/vars}}
 {{/hasEnums}}
+
+// operator< is needed for std::set support
+friend operator<(const {{classname}}& l, const {{classname}}& r) {
+   return std::tie({{#vars}}l.{{baseName}}{{^-last}},{{/-last}}{{/vars}}) < std::tie({{#vars}}r.{{baseName}}{{^-last}},{{/-last}}{{/vars}});
+}
 
 {{#modelNamespaceDeclarations}}
 }

--- a/src/main/resources/cpp-modern-json/struct-header.mustache
+++ b/src/main/resources/cpp-modern-json/struct-header.mustache
@@ -1,5 +1,4 @@
 #include <nlohmann/json.hpp>
-#include <tuple>
 
 {{#hasOptional}}#include <optional>
 {{/hasOptional}}
@@ -48,6 +47,9 @@ struct {{classname}}{{#parent}} : public {{{parent}}}{{/parent}} {
 {{/vars}}
 {{/hasEnums}}
 
+// operator< is needed for std::set support
+friend bool operator<(const {{classname}}& l, const {{classname}}& r);
+
 {{#hasRequired}}    // required fields
 {{#vars}}
 {{#required}}    {{{datatypeWithEnum}}} {{baseName}};
@@ -77,11 +79,6 @@ inline std::string to_string({{classname}}::{{enumName}} value) {
 {{/isEnum}}
 {{/vars}}
 {{/hasEnums}}
-
-// operator< is needed for std::set support
-friend bool operator<(const {{classname}}& l, const {{classname}}& r) {
-   return std::tie({{#vars}}l.{{baseName}}{{^-last}},{{/-last}}{{/vars}}) < std::tie({{#vars}}r.{{baseName}}{{^-last}},{{/-last}}{{/vars}});
-}
 
 {{#modelNamespaceDeclarations}}
 }

--- a/src/main/resources/cpp-modern-json/struct-source.mustache
+++ b/src/main/resources/cpp-modern-json/struct-source.mustache
@@ -20,6 +20,10 @@ void {{classname}}::from_json(const ::nlohmann::json& j, {{classname}}& obj) {
 {{/vars}}
 }
 
+bool {{classname}}::operator<(const {{classname}}& l, const {{classname}}& r) {
+   return std::tie({{#vars}}l.{{baseName}}{{^-last}},{{/-last}}{{/vars}}) < std::tie({{#vars}}r.{{baseName}}{{^-last}},{{/-last}}{{/vars}});
+}
+
 
 {{#hasEnums}}{{#vars}}{{#isEnum}}
 std::string {{classname}}::to_string({{classname}}::{{enumName}} value) {

--- a/src/main/resources/cpp-modern-json/struct-source.mustache
+++ b/src/main/resources/cpp-modern-json/struct-source.mustache
@@ -20,7 +20,7 @@ void {{classname}}::from_json(const ::nlohmann::json& j, {{classname}}& obj) {
 {{/vars}}
 }
 
-bool {{classname}}::operator<(const {{classname}}& l, const {{classname}}& r) {
+bool operator<(const {{classname}}& l, const {{classname}}& r) {
    return std::tie({{#vars}}l.{{baseName}}{{^-last}},{{/-last}}{{/vars}}) < std::tie({{#vars}}r.{{baseName}}{{^-last}},{{/-last}}{{/vars}});
 }
 


### PR DESCRIPTION
If an array has the `uniqueItems` property set to true, we will generate it as a `std::set` instead of a `std::vector`. In order to support pushing the dtos into a set, we must provide an `operator<`, which compares all members in a random order. This works, because each type will either be a comparable c++ type or another DTO, which also has an `operator<`.